### PR TITLE
Fixed remnant from old branding

### DIFF
--- a/aphelia.c
+++ b/aphelia.c
@@ -76,7 +76,7 @@ int main(void) {
                 system("dmenu_run");
             }
 
-            // Close uwurawrxdwm with mod+backspace
+            // Close aphelia with mod+backspace
     	    else if(ev.xkey.keycode == XKeysymToKeycode(display, XStringToKeysym("Backspace"))) {
                 XCloseDisplay(display);
             }


### PR DESCRIPTION
A line comment used the former name of the project instead of "aphelia." I fixed this -- just wasn't one hundred percent sure if you wanted "aphelia" or "Aphelia."