### PR TITLE
Added a logo variation for dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
-<h3 align="center"><img src="https://i.imgur.com/o8QXIco.png" alt="logo" height="100px"></h3>
+<h3 align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/e1f521ca-6e20-49e3-b5fa-4d1bef24b556">
+    <img alt="" src="https://i.imgur.com/o8QXIco.png" height="100px">
+  </picture>
+</h3>
 <p align="center">The minimalist window manager.</p>
 
 This project was previously a work of satire, going under a different name, however I have decided to continue the project as it seems functional and ready to be improved upon. [Click here if you're a little curious.](https://github.com/vardy/aphelia#satire)


### PR DESCRIPTION
Previous logotype was black and did not appear when browsing in dark mode, the most common mode. I inverted the colors and added the result as an alternative image. Pure white seemed too bright so I lowered colors with FFMPEG to F2F2F2, close to what GitHub text is colored like.

I also took the liberty to replace alt text from "logo" to an empty string. As acknowledging the logo is of no benefit to screenreader users, it's better for the program to just ignore it. At least that's what I learned in an accessibility lecture.